### PR TITLE
refactor: prepared dockerfile for multi-arch build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+!docker/
+!go.mod
+!proto/
+!test/
+!cmd/
+!go.sum
+!rabbitmq/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM golang:1.17.3-alpine
+# syntax=docker/dockerfile:1.2
+
+FROM --platform=${BUILDPLATFORM} golang:1.17.3-alpine
 WORKDIR $GOPATH/src/github.com/b2broker/conductor
 ENV CGO_ENABLED=0
 COPY . .
 RUN go mod download
 ARG TARGETOS TARGETARCH
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+RUN GOOS=${TARGETOS:-"linux"} GOARCH=${TARGETARCH:-"amd64"} \
     go build -ldflags="-w -s" -o /go/bin/conductor ./cmd/conductor
 
-FROM alpine
+FROM scratch
 COPY --from=0 /go/bin/conductor /conductor
 ENTRYPOINT ["/conductor"]


### PR DESCRIPTION
To issue multi-arch build via buildx use:
```
export DOCKER_BUILDKIT=1
docker buildx create --name builder 
docker buildx use builder
docker buildx inspect --bootstrap
docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/b2broker/conductor:{TAG} --push .
```